### PR TITLE
Infrastructure Fixes (#1):

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,7 +9,7 @@
 # Flags                                                              [ Config ]
 
 build --cxxopt=-std=c++20
-build --repo_env=CC=clang
+build --repo_env=CC=clang++
 
 # Required Flags                                                   [ Required ]
 

--- a/andromeda/core/system/event/type/monitor.hpp
+++ b/andromeda/core/system/event/type/monitor.hpp
@@ -5,7 +5,13 @@
 
 namespace Andromeda::System::Event {
     namespace Monitor {
-        struct Connect : Event < Type::Connect, Group::Instance + Group::Monitor > {};
-        struct Disconnect : Event < Type::Scroll, Group::Instance + Group::Monitor > {};
-    } /* Mouse */
+        struct Connect : Event < Type::Connect, Group::Instance + Group::Monitor > {
+            Connect() : Event({Andromeda::System::Structure::Status::Event::Unused}) {}
+            Connect(Andromeda::System::Structure::Status::Event status) : Event({status}) {}
+        };
+        struct Disconnect : Event < Type::Scroll, Group::Instance + Group::Monitor > {
+            Disconnect() : Event({Andromeda::System::Structure::Status::Event::Unused}) {}
+            Disconnect(Andromeda::System::Structure::Status::Event status) : Event({status}) {}
+        };
+    } /* Monitor */
 } /* Andromeda::System::Event */

--- a/andromeda/core/system/event/type/mouse.hpp
+++ b/andromeda/core/system/event/type/mouse.hpp
@@ -6,9 +6,13 @@
 namespace Andromeda::System::Event {
     namespace Mouse {
         struct Move : Event < Type::Move, Group::Input + Group::Mouse > {
+            Move(System::Structure::Duo<int> position) : Event({Andromeda::System::Structure::Status::Event::Unused}), position({position}) {}
+            Move(System::Structure::Duo<int> position, Andromeda::System::Structure::Status::Event status) : Event({status}), position({position}) {}
             System::Structure::Duo<int> position;
         };
         struct Scroll : Event < Type::Scroll, Group::Input + Group::Mouse > {
+            Scroll(System::Structure::Duo<float> offset) : Event({Andromeda::System::Structure::Status::Event::Unused}), offset({offset}) {}
+            Scroll(System::Structure::Duo<float> offset, Andromeda::System::Structure::Status::Event status) : Event({status}), offset({offset}) {}
             System::Structure::Duo<float> offset;
         };
     } /* Mouse */

--- a/andromeda/core/system/event/type/window.hpp
+++ b/andromeda/core/system/event/type/window.hpp
@@ -6,9 +6,13 @@
 namespace Andromeda::System::Event {
     namespace Window {
         struct Move : Event < Type::Move, Group::Instance + Group::Window > {
+            Move(System::Structure::Duo<int> position) : Event({Andromeda::System::Structure::Status::Event::Unused}), position({position}) {}
+            Move(System::Structure::Duo<int> position, Andromeda::System::Structure::Status::Event status) : Event({status}), position({position}) {}
             System::Structure::Duo<int> position;
         };
         struct Resize : Event < Type::Resize, Group::Instance + Group::Window > {
+            Resize(System::Structure::Duo<int> resize) : Event({Andromeda::System::Structure::Status::Event::Unused}), resize({resize}) {}
+            Resize(System::Structure::Duo<int> resize, Andromeda::System::Structure::Status::Event status) : Event({status}), resize({resize}) {}
             System::Structure::Duo<int> resize;
         };
         struct Close : Event < Type::Close, Group::Instance + Group::Window > {};

--- a/andromeda/core/system/graphics/display/manager.hpp
+++ b/andromeda/core/system/graphics/display/manager.hpp
@@ -3,12 +3,15 @@
 #include "monitor.hpp"
 #include "window.hpp"
 
+#include <memory>
+
 namespace Andromeda::System::Graphics::Display {
     class Manager {
       public:
         virtual ~Manager() = default;
 
         virtual void initialize() = 0;
+        virtual void update() = 0;
 
         virtual void create(Window::Configuration configuration) = 0;
     };

--- a/andromeda/core/system/platform/linux/graphics/display/manager.cpp
+++ b/andromeda/core/system/platform/linux/graphics/display/manager.cpp
@@ -3,6 +3,7 @@
 #include "andromeda/core/system/log/log.hpp"
 
 #include <GLFW/glfw3.h>
+
 namespace Andromeda::System::Linux::Graphics::Display {
     Manager::Manager() {
         initialize();
@@ -15,9 +16,12 @@ namespace Andromeda::System::Linux::Graphics::Display {
         glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
         int count = 0;
         auto monitors = glfwGetMonitors(&count);
-        for (int monitor = 0; monitor < count; monitor++) m_Monitors.push_back(monitors[monitor]);
+        for (int monitor = 0; monitor < count; monitor++) m_Monitors.push_back(std::make_unique<Andromeda::System::Linux::Graphics::Display::Monitor>(monitors[monitor]));
+    }
+    void Manager::update() {
+
     }
     void Manager::create(Andromeda::System::Graphics::Display::Window::Configuration configuration) {
-        m_Windows.emplace_back(configuration);
+        m_Windows.push_back(std::make_unique<Andromeda::System::Linux::Graphics::Display::Window>(configuration));
     }
 } /* Andromeda::System::Graphics::Display */

--- a/andromeda/core/system/platform/linux/graphics/display/manager.hpp
+++ b/andromeda/core/system/platform/linux/graphics/display/manager.hpp
@@ -7,16 +7,18 @@
 
 #include <memory>
 namespace Andromeda::System::Linux::Graphics::Display {
-    class Manager : Andromeda::System::Graphics::Display::Manager {
+    class Manager : public Andromeda::System::Graphics::Display::Manager {
       public:
         Manager();
         ~Manager() override;
 
         void initialize() override;
+        void update() override;
 
         void create(Andromeda::System::Graphics::Display::Window::Configuration configuration) override;
+
       private:
-        std::vector<Andromeda::System::Linux::Graphics::Display::Monitor> m_Monitors;
-        std::vector<Andromeda::System::Linux::Graphics::Display::Window> m_Windows;
+        std::vector<std::unique_ptr<Andromeda::System::Graphics::Display::Monitor>> m_Monitors;
+        std::vector<std::unique_ptr<Andromeda::System::Graphics::Display::Window>> m_Windows;
     };
 } /* Andromeda::System::Graphics::Display */

--- a/andromeda/core/system/platform/linux/graphics/display/monitor.cpp
+++ b/andromeda/core/system/platform/linux/graphics/display/monitor.cpp
@@ -5,10 +5,6 @@ namespace Andromeda::System::Linux::Graphics::Display {
         glfwSetMonitorUserPointer(m_Native, & m_Configuration);
         update();
     }
-    Monitor::~Monitor() {
-
-    }
-
     void Monitor::update() {
         m_Configuration.title = std::string(glfwGetMonitorName(m_Native));
         glfwGetMonitorPos(m_Native, & m_Configuration.position.x, & m_Configuration.position.y);

--- a/andromeda/core/system/platform/linux/graphics/display/monitor.hpp
+++ b/andromeda/core/system/platform/linux/graphics/display/monitor.hpp
@@ -5,10 +5,9 @@
 #include <GLFW/glfw3.h>
 
 namespace Andromeda::System::Linux::Graphics::Display {
-    class Monitor : Andromeda::System::Graphics::Display::Monitor {
+    class Monitor : public Andromeda::System::Graphics::Display::Monitor {
       public:
         Monitor(GLFWmonitor * monitor);
-        ~Monitor() override;
 
         void update() override;
       private:

--- a/andromeda/core/system/platform/linux/graphics/display/window.hpp
+++ b/andromeda/core/system/platform/linux/graphics/display/window.hpp
@@ -7,7 +7,7 @@
 #include <memory>
 
 namespace Andromeda::System::Linux::Graphics::Display {
-    class Window : Andromeda::System::Graphics::Display::Window {
+    class Window : public Andromeda::System::Graphics::Display::Window {
       public:
         Window(Window::Configuration configuration);
         ~Window() override;

--- a/andromeda/core/system/structure/status.hpp
+++ b/andromeda/core/system/structure/status.hpp
@@ -17,5 +17,6 @@ namespace Andromeda::System::Structure::Status {
     };
     enum class Error {
         Undefined = 0,
+        None,
     };
 } /* Andromeda::System::Structure::Status */

--- a/andromeda/test/core/instance.cc
+++ b/andromeda/test/core/instance.cc
@@ -7,7 +7,8 @@ class Basic : public Andromeda::Instance {
     Basic(Andromeda::Instance::Configuration configuration) :
         m_Configuration(configuration),
         m_State({
-        .status = Andromeda::System::Structure::Status::Runtime::Nullified
+        .status = Andromeda::System::Structure::Status::Runtime::Nullified,
+        .error = Andromeda::System::Structure::Status::Error::None,
     }) {
         m_State.status = Andromeda::System::Structure::Status::Runtime::Nullified;
     }
@@ -41,7 +42,7 @@ class Basic : public Andromeda::Instance {
 
     int code() const override {
         switch (m_State.error) {
-            case Andromeda::System::Structure::Status::Error::Undefined :
+            case Andromeda::System::Structure::Status::Error::Undefined:
                 return 0;
             default:
                 return 0;

--- a/andromeda/test/core/system/event/type/mouse.cc
+++ b/andromeda/test/core/system/event/type/mouse.cc
@@ -4,9 +4,7 @@
 
 TEST(Event, Move) {
     EXPECT_NO_THROW({
-        auto move = Andromeda::System::Event::Mouse::Move({
-            .position = {3, 2},
-        });
+        auto move = Andromeda::System::Event::Mouse::Move({3, 2});
         EXPECT_EQ(move.status, Andromeda::System::Structure::Status::Event::Unused);
         move.status = Andromeda::System::Structure::Status::Event::Used;
     });
@@ -14,10 +12,7 @@ TEST(Event, Move) {
 
 TEST(Event, Scroll) {
     EXPECT_NO_THROW({
-        auto scroll = Andromeda::System::Event::Mouse::Scroll({
-            {},
-            {20.0, -1.0},
-        });
+        auto scroll = Andromeda::System::Event::Mouse::Scroll({20.0, -1.0});
         EXPECT_EQ(scroll.status, Andromeda::System::Structure::Status::Event::Unused);
         scroll.status = Andromeda::System::Structure::Status::Event::Used;
     });

--- a/andromeda/test/core/system/event/type/window.cc
+++ b/andromeda/test/core/system/event/type/window.cc
@@ -4,9 +4,7 @@
 
 TEST(Event, Move) {
     EXPECT_NO_THROW({
-        auto move = Andromeda::System::Event::Window::Move({
-            .position = {3, 2},
-        });
+        auto move = Andromeda::System::Event::Window::Move({3, 2});
         EXPECT_EQ(move.status, Andromeda::System::Structure::Status::Event::Unused);
         move.status = Andromeda::System::Structure::Status::Event::Used;
     });
@@ -14,10 +12,7 @@ TEST(Event, Move) {
 
 TEST(Event, Resize) {
     EXPECT_NO_THROW({
-        auto resize = Andromeda::System::Event::Window::Resize({
-            {},
-            {3, 2},
-        });
+        auto resize = Andromeda::System::Event::Window::Resize({3, 2});
         EXPECT_EQ(resize.status, Andromeda::System::Structure::Status::Event::Unused);
         resize.status = Andromeda::System::Structure::Status::Event::Used;
     });


### PR DESCRIPTION
    - Use clang++ alias
    - Event explicit constructors
    - Test changes
    - Window base
    - Monitor base
    - Remove unused methods